### PR TITLE
Fix save all celltype probabilities keras flag

### DIFF
--- a/modules/nf-core/modules/keras_celltype/main.nf
+++ b/modules/nf-core/modules/keras_celltype/main.nf
@@ -41,6 +41,7 @@ process KERAS_CELLTYPE {
             --keras_weights_df \"${params.celltype_prediction.keras.keras_weights_df}\" \\
             --keras_model_cluster_labels \"${params.celltype_prediction.keras.keras_model_cluster_labels}\" \\
             --filter_top_cell_probabilities \"${params.celltype_prediction.keras.filter_top_cell_probabilities}\" \\
-            --output_file \"${experiment_id}___cellbender_fpr${params.cellbender_resolution_to_use}-scrublet-ti_freeze003_prediction\" ${params.celltype_prediction.keras.save_all_probabilities} 
+            \"${params.celltype_prediction.keras.save_all_probabilities}\" \\
+            --output_file \"${experiment_id}___cellbender_fpr${params.cellbender_resolution_to_use}-scrublet-ti_freeze003_prediction\" 
         """
 }


### PR DESCRIPTION
Keras flag to save all probabilities wasn't working in previous release
